### PR TITLE
updated dependencies to support upstart and mysql_chef_game

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,16 +1,23 @@
 ---
-driver_plugin: vagrant
+driver:
+  name: vagrant
+
 driver_config:
-  require_chef_omnibus: "11.6.0"
-  box: precise64
-  box_url: http://files.vagrantup.com/precise64.box
-  network:
-  - ["private_network", {ip: "192.168.33.33"}]
-  customize:
-    memory: 2048
-  
+  require_chef_omnibus: 11.12.4
+
+provisioner:
+  name: chef_zero
+
 platforms:
-- name: ubuntu-12.04
+  - name: ubuntu-12.04
+    driver_config:
+      box: opscode-ubuntu-12.04
+      box_url: https://opscode-vm.s3.amazonaws.com/vagrant/boxes/opscode-ubuntu-12.04.box
+      require_chef_omnibus: 11.12.4
+      customize:
+        memory: 2048
+      network:
+      - ["private_network", {ip: "192.168.33.33"}]
 
 suites:
 - name: artifactory

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
+gem "berkshelf", "=2.0.18"
 gem 'chef-rewind'
 gem 'chef-sugar'
 
@@ -10,6 +10,7 @@ group :test do
   gem 'chefspec'
   gem 'guard'
   gem 'guard-rspec'
+  gem 'rake'
 end
 
 group :integration do

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ group :test do
 end
 
 group :integration do
-  gem 'test-kitchen', '~> 1.1.1'
+  gem 'test-kitchen'
   gem 'kitchen-vagrant'
+  gem 'busser-serverspec'
   gem 'serverspec'
-  gem 'busser'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,24 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+namespace :test do
+  begin
+    require 'kitchen/rake_tasks'
+    Kitchen::RakeTasks.new
+  rescue LoadError
+    puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+  end
+
+  desc 'Run all of the quick tests.'
+  task :spec do
+    Rake::Task['spec'].invoke
+  end
+
+  desc 'Run _all_ the tests. Go get a coffee.'
+  task :complete do
+    Rake::Task['test:spec'].invoke
+    Rake::Task['test:kitchen:all'].invoke
+  end
+  task :default => :spec
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,7 +28,7 @@ default['artifactory']['catalina']['max_spare_threads']       = 150
 default['artifactory']['catalina']['enable_lookups']          = false
 default['artifactory']['catalina']['disable_upload_timeout']  = true
 default['artifactory']['catalina']['backlog']                 = 100
-
+default['artifactory']['init_service']                        = 'runit'
 default['artifactory']['database']['name']                    = 'artifactory'
 default['artifactory']['databag']                             = 'artifactory'
 default['artifactory']['databag_item']                        = 'credentials'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,12 @@ default['java']['install_flavor'] = 'openjdk'
 default['java']['openjdk_packages'] = ['openjdk-7-jre-headless', 'openjdk-7-jdk']
 default['java']['jdk_version'] = '7'
 
+default['mysql']['databag'] = 'mysql'
+default['mysql']['databag_item'] = 'credentials'
+default['mysql']['version'] = '5.5'
+default['mysql']['bind_address'] = '0.0.0.0'
+default['mysql']['port'] = '3306'
+
 default['artifactory']['version'] = '3.5.1'
 default['artifactory']['checksum'] = 'b6ae87d5ce044975af9965ac833c91e9c64b9ece3ececb59007a3c33749367e4'
 default['artifactory']['user'] = 'artifactory'
@@ -23,3 +29,6 @@ default['artifactory']['catalina']['enable_lookups']          = false
 default['artifactory']['catalina']['disable_upload_timeout']  = true
 default['artifactory']['catalina']['backlog']                 = 100
 
+default['artifactory']['database']['name']                    = 'artifactory'
+default['artifactory']['databag']                             = 'artifactory'
+default['artifactory']['databag_item']                        = 'credentials'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,8 @@ description      "Sets up open-source artifactory"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version "0.1.0"
 
+supports 'debian'
+
 depends "runit"
 depends "ark"
 depends "apt"

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,5 +10,6 @@ depends "runit"
 depends "ark"
 depends "apt"
 depends "java", "~> 1.16"
-depends "mysql", "= 5.2.12"
-depends "database", "= 4.0.2"
+depends "mysql", '~> 6.0'
+depends "database", "= 4.0.5"
+depends 'mysql2_chef_gem', '~> 1.0'

--- a/recipes/_database.rb
+++ b/recipes/_database.rb
@@ -1,3 +1,3 @@
-if node['artifactory']['database']['type'].upcase == "MYSQL"
+if node['artifactory']['database']['type'] && node['artifactory']['database']['type'].upcase == "MYSQL"
   include_recipe "artifactory::mysql"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,7 @@ include_recipe "artifactory::_tomcat"
 execute "change-executable-permission" do
   command "find #{node['artifactory']['dir']} -type f -name '*.sh' -exec chmod +x {} \\;"
   user "root"
-  notifies :restart, 'service[artifactory]'
+  notifies :restart, 'service[artifactory]', :delayed
 end
 
 runit_service 'artifactory' do
@@ -39,4 +39,5 @@ runit_service 'artifactory' do
                            ].join(" "),
         "ARTIFACTORY_HOME" => node['artifactory']['dir']
       })
+  subscribes :restart, "template [#{node['artifactory']['dir']}/etc/storage.properties]", :immediately
 end

--- a/templates/default/artifactory.conf.erb
+++ b/templates/default/artifactory.conf.erb
@@ -1,0 +1,18 @@
+description "Tomcat Server"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+respawn
+respawn limit 10 5
+
+setuid artifactory
+setgid artifactory
+
+<% @env.each_pair do |key, value| %>
+env <%= key.upcase %>="<%= value %>"
+<% end %>
+
+exec <%= node['artifactory']['dir'] %>/tomcat/bin/catalina.sh run
+
+
+

--- a/templates/default/storage/mysql.properties.erb
+++ b/templates/default/storage/mysql.properties.erb
@@ -1,8 +1,8 @@
 type=mysql
 driver=com.mysql.jdbc.Driver
 url=<%= "jdbc:mysql://#{node['mysql']['bind_address']}:#{node['mysql']['port']}/#{node['artifactory']['database']['name']}?characterEncoding=UTF-8&elideSetAutoCommits=true" %>
-username=<%= node['artifactory']['database']['username'] %>
-password=<%= node['artifactory']['database']['password'] %>
+username=<%= @artifactory_creds['mysql']['username'] %>
+password=<%= @artifactory_creds['mysql']['password'] %>
 
 ## Determines where the actual artifacts binaries are stored. Available options:
 ## filesystem - binaries are stored in the filesystem (recommended, default)


### PR DESCRIPTION
I updated a few things:
1. Using msyql_chef_gem instead of chef_gem as per recommendations on the database cookbook. This resulted in upgrading the version of database and mysql cookbooks.
2. Support upstart, this can be set via default['artifactory'][init_service'], default is set to runit.
3. Set mysql and artifactory database passwords via an encrypted data bag. 
4. updated Gemfile and Rakefile